### PR TITLE
Fixing dates

### DIFF
--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          fetch-depth: '1'
+          fetch-depth: '0'
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: '1'
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
The dates only applied to the current commit. This allows the GitHub action to see all commits. This tells us how old our files are on the website.